### PR TITLE
Added library.json for use with platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -21,5 +21,9 @@
     ],
     "license": "The Unlicense",
     "frameworks": "Arduino",
-    "platforms": ["espressif8266"]
+    "platforms": ["espressif8266"],
+    "dependencies": [
+        "Time",
+        "EspSoftwareSerial"
+    ]
   }

--- a/library.json
+++ b/library.json
@@ -1,0 +1,25 @@
+{
+    "name": "DebugPrint",
+    "version": "1.0.0",
+    "description": "Library for ESP8266 debug printings",
+    "keywords": [
+        "telnet", 
+        "print", 
+        "debug"
+    ],
+    "repository":
+    {
+      "type": "git",
+      "url": "https://github.com/Pako2/DebugPrint"
+    },
+    "examples": [
+        {
+            "name": "DebugPrint NTPClient Demo",
+            "base": "examples/DebugPrint_NTPClient_Demo",
+            "files": ["DebugPrint_NTPClient_Demo.ino"]
+        }
+    ],
+    "license": "The Unlicense",
+    "frameworks": "Arduino",
+    "platforms": ["espressif8266"]
+  }


### PR DESCRIPTION
Hey, thanks for putting together a neat lib! :)

I was looking around for a lib to use and found yours, but found that it wasn't available on platformio for easy integration into my project. I added the required manifest in this PR.

If you want, I can add myself as a maintainer on the lib, and I can register it with platformio.
I also wasn't sure if this library works with ESP32, so for now I just set the platform to espressif8266. If it works on esp32, I'll add that platform as well. 