### PR TITLE
Fixed miswritten manifest fields

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "DebugPrint",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Library for ESP8266 debug printings",
     "keywords": [
         "telnet", 

--- a/library.json
+++ b/library.json
@@ -24,7 +24,6 @@
     "platforms": ["espressif8266"],
     "dependencies": [
         "Time",
-        "EspSoftwareSerial",
-	"NTPClient"
+        "EspSoftwareSerial"
     ]
   }

--- a/library.json
+++ b/library.json
@@ -14,12 +14,12 @@
     },
     "examples": [
         {
-            "name": "DebugPrint NTPClient Demo",
+            "name": "DebugPrint_NTPClient_Demo",
             "base": "examples/DebugPrint_NTPClient_Demo",
             "files": ["DebugPrint_NTPClient_Demo.ino"]
         }
     ],
-    "license": "The Unlicense",
+    "license": "Unlicense",
     "frameworks": "Arduino",
     "platforms": ["espressif8266"],
     "dependencies": [

--- a/library.json
+++ b/library.json
@@ -24,6 +24,7 @@
     "platforms": ["espressif8266"],
     "dependencies": [
         "Time",
-        "EspSoftwareSerial"
+        "EspSoftwareSerial",
+	"NTPClient"
     ]
   }

--- a/library.json
+++ b/library.json
@@ -19,6 +19,18 @@
             "files": ["DebugPrint_NTPClient_Demo.ino"]
         }
     ],
+    "authors":
+    [
+        {
+            "name": "Pako2",
+            "url": "https://github.com/Pako2"
+        },
+        {
+            "name": "Duckle29",
+            "url": "https://github.com/Duckle29",
+            "maintainer": true
+        }
+    ],
     "license": "Unlicense",
     "frameworks": "Arduino",
     "platforms": ["espressif8266"],


### PR DESCRIPTION
Hey there. Happy to see my previous PR merged. I forgot examples couldn't have spaces in their name, and picked the license from the wrong column on the look-up table. Should be fixed now, and platformio packages it without complaining :)